### PR TITLE
Initial SSL support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,40 +67,55 @@ So you like the idea of this and want to give it a go.  Here's how:
 
 Dependencies:
 -------------
-- *node.js*: for server, confirmed working v.10.9, and should be OK with v.10.* -- node-sass has troubles with v.11.*-pre
 
-> git pull https://github.com/joyent/node.git
+### node.js 
 
-> ./configure
+For server, confirmed working v0.10.10, and should be OK with v0.10.1*.
 
-> make
+    $ git pull https://github.com/joyent/node.git
+    $ git checkout v0.10.10
+    $ ./configure
+    $ make
+    $ make install
 
-> make install
+Known Issues:
 
-- *phantomjs* (optional): for taking screenshots of websites to embed in the chat
+- Node v0.10.8 and v0.10.9 have an [incompatibility with socket.io and HTTPS](https://github.com/joyent/node/pull/5624).
+- Node v0.11.* has issues with node-sass.
+
+
+### node.js Packages
+
+    $ npm install
+
+### Redis
+
+For persistence.
+
+    $ sudo apt-get install redis-server
+
+### PhantomJS (optional)
+
+For taking screenshots of websites to embed in the chat.
+
 Download from http://phantomjs.org/
-Install the binary to /opt/bin/phantomjs
 
-If you don't want to do this step, set "phantomjs_screenshot" to false in server/config.js
+Install the binary to `/opt/bin/phantomjs`
+
+If you don't want to do this step, set "phantomjs_screenshot" to false in `server/config.js`. 
 This step also requires cloning the [phantomjs-screenshot](https://github.com/qq99/phantomjs-screenshot) repository beside this repo.
-
-- *redis*: for persistence
-> sudo apt-get install redis-server
-
-- *node packages*
-> npm install
 
 Building:
 ---------
 
 `npm run-script build`
 
-
 Running the server:
 -------------------
 
 Create a copy of the sample config file for the server, and change any relevant options:
-> cp server/config.sample.js server/config.js
+
+    $ cp server/config.sample.js server/config.js
 
 Run `npm start` or `nodemon server/main.js` or `node server/main.js`.  It will become available on http://localhost:8080/ under the default configuration.
 

--- a/server/config.sample.js
+++ b/server/config.sample.js
@@ -8,6 +8,10 @@
 			PORT: 8080,
 			USE_PORT_IN_URL: true,
 		},
+		ssl: {
+			PRIVATE_KEY: '/path/to/server.key',
+			CERTIFICATE: '/path/to/certificate.crt'
+		},
 		features: {
 			SERVER_NICK: 'Server',
 			phantomjs_screenshot: false, // http://www.youtube.com/watch?feature=player_detailpage&v=k3-zaTr6OUo#t=23s

--- a/server/main.js
+++ b/server/main.js
@@ -1,3 +1,5 @@
+var config = require('./config.js').Configuration;
+
 var express = require('express'),
 	_ = require('underscore'),
 	Backbone = require('backbone'),
@@ -7,7 +9,6 @@ var express = require('express'),
 	sio = require('socket.io'),
 	app = express(),
 	redisC = redis.createClient(),
-	server = require('http').createServer(app),
 	spawn = require('child_process').spawn,
 	async = require('async'),
 	chatServer = require('./ChatServer.js').ChatServer,
@@ -16,7 +17,16 @@ var express = require('express'),
 	PUBLIC_FOLDER = __dirname + '/../public',
 	SANDBOXED_FOLDER = PUBLIC_FOLDER + '/sandbox';
 
-var config = require('./config.js').Configuration;
+var protocol = require(config.host.SCHEME);
+
+if (config.host.SCHEME == 'https') {
+	var privateKey  = fs.readFileSync(config.ssl.PRIVATE_KEY).toString();
+	var certificate = fs.readFileSync(config.ssl.CERTIFICATE).toString();
+	var credentials = { key: privateKey, cert: certificate };
+	var server = protocol.createServer(credentials, app); 
+} else {
+	var server = protocol.createServer(app);
+}
 
 // Custom objects:
 // shared with the client:


### PR DESCRIPTION
Addresses most of qq99/echoplexus#3, still need to ensure secure cookies.

A note, Node `v0.10.8` and `v0.10.9` are incompatible with `socket.io` and HTTPS. It is noted in the README. As a side-note, I was able to get the server running with HTTPS on `v0.10.7`.

POC: https://chat.socialeng.net
