### PR TITLE
No longer de-escalate the PhantomJS user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,28 @@ Currently, interactive and collaborative HTML & JavaScript is supported, with ev
 Security
 --------
 
-*echoplexus is not secure, but it's getting there.*  Your registration, identification, and private channel passwords are first salted with 256 random bytes from node's `crypto.randomBytes`.  Then, they are run through 4096 iterations of `crypto.pbkdf2` with a key length of 256 bytes before the is stored in redis.  Of course, this is meaningless since there isn't HTTPS by default (for that, I apologize).  I'd especially appreciate any input in securing echoplexus.  You should rest assured that this project will take security very seriously.  *Currently, the chatlogs of a private channel are not encrypted!*
+*echoplexus is not secure, but it's getting there.*  Your registration, 
+identification, and private channel passwords are first salted with 256 random 
+bytes from node's `crypto.randomBytes`.  Then, they are run through 4096 
+iterations of `crypto.pbkdf2` with a key length of 256 bytes before the is 
+stored in Redis.  Of course, this is meaningless since there isn't HTTPS by 
+default (for that, I apologize).  I'd especially appreciate any input in 
+securing echoplexus.  You should rest assured that this project will take 
+security very seriously.  *Currently, the chatlogs of a private channel are not
+encrypted!*
 
-The phantomjs_screenshotting is currently accomplished by starting as the rooter user, then immediately dropping privileges to another sandboxed user (named sandbox) who hopefully should be more limited under an attack.  This really makes me nervous.
+It is recommended to setup a non-privileged user for `echoplexus` and run `node.js` 
+as this user on a non-privileged port (default is `8080`). From there, you may do
+one of the following, depending on your needs:
 
-If you're using it on a relatively private server or on a LAN, you should have little worries.
+1. Pro: Proxy echoplexus behind nginx v1.3.13 or later (requires WebSocket 
+   support). You may also use HAProxy.
+2. Git'r done: Update iptables to redirect port 80 or 443 to the port of your 
+   choice. *Remember to save and test your rules!*
+
+Example:
+
+    $ iptables  -t nat -I PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8080
 
 Draw
 ----

--- a/server/ChatServer.js
+++ b/server/ChatServer.js
@@ -319,7 +319,7 @@ exports.ChatServer = function (sio, redisC, EventBus) {
 								you: true
 							}));
 
-							if (config.features.phantomjs_screenshot) {
+							if (config.features.PHANTOMJS_SCREENSHOT) {
 								// strip out other things the client is doing before we attempt to render the web page
 								var urls = data.body.replace(REGEXES.urls.image, "")
 													.replace(REGEXES.urls.youtube,"")
@@ -335,7 +335,7 @@ exports.ChatServer = function (sio, redisC, EventBus) {
 											
 											DEBUG && console.log("Processing ", urls[i]);
 											// requires that the phantomjs-screenshot repo is a sibling repo of this one
-											var screenshotter = spawn('/opt/bin/phantomjs',
+											var screenshotter = spawn(config.features.PHANTOMJS_PATH),
 												['../../phantomjs-screenshot/main.js', url, output],
 												{
 													cwd: __dirname

--- a/server/config.sample.js
+++ b/server/config.sample.js
@@ -14,7 +14,8 @@
 		},
 		features: {
 			SERVER_NICK: 'Server',
-			phantomjs_screenshot: false, // http://www.youtube.com/watch?feature=player_detailpage&v=k3-zaTr6OUo#t=23s
+			PHANTOMJS_SCREENSHOT: false, // http://www.youtube.com/watch?feature=player_detailpage&v=k3-zaTr6OUo#t=23s
+			PHANTOMJS_PATH: '/opt/bin/phantomjs'
 		},
 		DEBUG: false
 	};

--- a/server/main.js
+++ b/server/main.js
@@ -34,14 +34,6 @@ var Client = require('../client/client.js').ClientModel,
 	Clients = require('../client/client.js').ClientsCollection,
 	REGEXES = require('../client/regex.js').REGEXES;
 
-// special things to do on init:
-if (config.features.phantomjs_screenshot) { // change the user of the current process
-	process.setgid('sandbox');
-	process.setuid('sandbox');
-	console.log('Now leaving the DANGERZONE!', 'New User ID:', process.getuid(), 'New Group ID:', process.getgid());
-	console.log('Probably still a somewhat dangerous zone, tho.');
-}
-
 // Web server init:
 app.use(express.static(PUBLIC_FOLDER));
 // always server up the index.html


### PR DESCRIPTION
The de-escalation is removed. Updated the README to reflect a better installation. It's also preferred because:
1. `node.js` is no longer running as root.
2. `phantomjs` doesn't need a odd-man `sandbox` user. Images will be generated and owned by the user the app should be running under, a non-privileged user.
3. Additionally, culled out the `/opt/bin/phantomjs` path so users may use different install paths.
